### PR TITLE
Update Bio-Formats to 5.9.2-SNAPSHOT

### DIFF
--- a/trunk/java/build.gradle
+++ b/trunk/java/build.gradle
@@ -30,7 +30,7 @@ configurations.all {
 dependencies {
     compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
-    compile group: 'ome', name: 'formats-gpl', version: '5.3.3-SNAPSHOT'
+    compile group: 'ome', name: 'formats-gpl', version: '5.9.2-SNAPSHOT'
     compile 'net.sourceforge.argparse4j:argparse4j:0.7.0'
     testCompile 'org.testng:testng:6.9.10'
 }


### PR DESCRIPTION
5.3.3-SNAPSHOT is over 2 years old at this point, and in particular does not include recent improvements to Deltavision support.  5.9.2-SNAPSHOT is the latest on the 5.x line.